### PR TITLE
Fix - Auto Initialization

### DIFF
--- a/A3A/addons/core/functions/OrgPlayers/fn_assignBossIfNone.sqf
+++ b/A3A/addons/core/functions/OrgPlayers/fn_assignBossIfNone.sqf
@@ -50,6 +50,35 @@ if (!isNull _nextBoss) then
 else
 {
     Info("Couldn't select a new boss - no eligible candidates.");
+    // Make the boss a random player - Fixed Auto Init "Reaper"
+
+    private _players = allPlayers select {alive _x && side _x == teamPlayer};
+
+        // Ensure R is initialized in the mission namespace
+        if (isNil {missionNamespace getVariable "R"}) then { 
+            missionNamespace setVariable ["R", 0, true]; 
+        };
+
+        if ((missionNamespace getVariable "R") == 0 && (count _players) > 0) then {
+            missionNamespace setVariable ["R", 1, true]; // Ensure this command only runs once
+            theBoss = selectRandom _players;
+            publicVariable "theBoss"; // Broadcast the change
+            ["New commander assigned: " + name theBoss, "hint"] call A3A_fnc_customHint;
+    
+    // Remove the boss after 60 seconds
+            [] spawn {
+                sleep 60;
+                if (!isNull theBoss) then {
+                    theBoss = objNull;
+                    publicVariable "theBoss";
+                    ["The commander has been removed after 60 seconds.", "hint"] call A3A_fnc_customHint;
+                };
+            };
+    } else {
+        ["No eligible players to assign as the commander or command already executed.", "hint"] call A3A_fnc_customHint;
+    };
+
+
     // Remove current boss if any, as they're ineligible
     if (!isNull theBoss) then { [] call A3A_fnc_theBossTransfer };
 };


### PR DESCRIPTION
Fixed auto initialization when a server member or admin is not present after restart.

## What type of PR is this?
1. [ X] Bug
2. [X ] Change
3. [ ] Enhancement
4. [ ] Miscellaneous

### What have you changed and why?
Information:
Fixed auto initialization when server member or admin is not present after restart.
### Please specify which Issue this PR Resolves (If Applicable).
"This PR closes #XXXX!"

### Please verify the following.

1. [ X] Have you loaded the mission in LAN host?
2. [X ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?

1. [X ] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps:
Launch pre configured dedicated server with guest commander disabled. Have a non server member / admin join the game. Game will be fully initialized
********************************************************
Notes:
